### PR TITLE
Add DockerFile and change group name of project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM gradle:jdk17-alpine AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon
+
+FROM eclipse-temurin:17-ubi9-minimal
+EXPOSE 9001
+RUN mkdir /app
+COPY --from=build /home/gradle/src/build/libs/*all*.jar /app/fit-server.jar
+
+ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-Djava.security.egd=file:/dev/./urandom","-jar","/app/fit-server.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     application
 }
 
-group = "net.finalatomicbuster"
+group = "org.bikehopper"
 version = "1.0-SNAPSHOT"
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version "1.7.20"
     kotlin("plugin.serialization") version "1.7.20"
+    id("com.github.johnrengelman.shadow") version "7.1.2"
     application
 }
 


### PR DESCRIPTION
This update adds a Docker file that does the following.
- Pulls down gradle, uses that to build a uberJar via shadow
- Pulls down eclipse-temurin and copies the uberJar to that
- Sets an entry point to execute the uberJar

Also updated the group name from my domain to bikehoppers.

Here is a screen shot of the docker build
![image](https://user-images.githubusercontent.com/4640602/202945939-c35aaa65-09ec-4938-9fce-a718ddf7ffce.png)
