### PR TITLE
Fix bug - local build did not work + up version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM gradle:jdk17-alpine AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
+RUN gradle clean
 RUN gradle build --no-daemon
 
 FROM eclipse-temurin:17-ubi9-minimal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.bikehopper"
-version = "0.1.2-SNAPSHOT"
+version = "0.1.3-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+docker build .

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,2 @@
 
 rootProject.name = "bikeHopperFitFileCreator"
-

--- a/src/main/kotlin/Server.kt
+++ b/src/main/kotlin/Server.kt
@@ -5,9 +5,11 @@ import io.javalin.Javalin
 import io.ktor.client.plugins.*
 import org.slf4j.LoggerFactory;
 
+
 fun main() {
     val app = Javalin.create(/* TODO: Config */)
     val logger = LoggerFactory.getLogger("Server")
+    logger.info("Starting BikeHopperServer v0.1.3")
 
     app.before { ctx ->
         logger.info("Request: ${ctx.method()} ${ctx.path()} params: ${ctx.queryParamMap()}")


### PR DESCRIPTION
Building multiple times locally via docker would create multiple files in our build directory, causing our Dockerfile to crash when trying to copy the shadowJar.

Fixed this by adding a CLEAN step which removes all files that may exist locally before the copy to Docker.